### PR TITLE
change `staring` to `starting` to fix typo

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -133,7 +133,7 @@ performance.mark("myApp.stateChange", {
 });
 
 // Measuring time durations
-performance.mark("userAction.start"); // marks staring point
+performance.mark("userAction.start"); // marks starting point
 performance.measure("userAction.duration", "userAction.start"); // measures from starting point
 ```
 


### PR DESCRIPTION
This is the only typo I found in 019ebae1f3c2bd4b1e47ac2fc83d2a4e45814311.

I recommend [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker), especially for `.md` files, although I don't think it would have caught this.