### PR TITLE
make minor grammatical changes to `docs/cpu.md`

### DIFF
--- a/docs/cpu.md
+++ b/docs/cpu.md
@@ -6,13 +6,13 @@ title: CPU
 
 :::caution
 
-**This API is only supported in electron. It is only supported in renderer processes with `nodeIntegration` enabled**
+**This API is only supported in Electron. It is only supported in renderer processes with `nodeIntegration` enabled**.
 
 :::
 
 ### Usage
 
-The CPU plugin collects CPU samples from electron's renderer and main processes.
+The CPU plugin collects CPU samples from Electron's renderer and main processes.
 
 ```ts {6} title="main.js (main process)"
 import { init, cpu } from "@palette.dev/electron/main";


### PR DESCRIPTION
I think at least some users may not know what Electron is, and capitalizing it lets them know it's the name of a thing that's not a subatomic particle.